### PR TITLE
Add Visu3d to the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [Survey](#survey) 
 - [Papers](#papers)
 - [Talks](#talks)
+- [Implementations](#implementations)
 
 ## Survey
 - [Neural Volume Rendering: NeRF And Beyond](https://arxiv.org/abs/2101.05204), Dellaert and Yen-Chen, Arxiv 2020 | [blog](https://dellaert.github.io/NeRF/) | [github](https://raw.githubusercontent.com/yenchenlin/awesome-NeRF/main/NeRF-and-Beyond.bib) | [bibtex](https://github.com/yenchenlin/awesome-NeRF/blob/main/citations/nerf-survey.txt)

--- a/README.md
+++ b/README.md
@@ -145,5 +145,8 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [JaxNeRF](https://github.com/google-research/google-research/tree/master/jaxnerf), Deng et al., 2020 | [bibtex](https://github.com/yenchenlin/awesome-NeRF/blob/main/NeRF-and-Beyond.bib#L55-L60)
 - [Mip-NeRF](https://github.com/google/mipnerf), [@google](https://github.com/google), 2021 | [bibtex](./citations/mipnerf.txt)
 
+#### Libraries
+- [Visu3d](https://github.com/google-research/visu3d), [@google](https://github.com/google-research), 2022
+
 ## License 
 MIT


### PR DESCRIPTION
Visu3d is a library to help build Nerf-like ML models (in TF, Jax and Numpy).
Among things, it includes differentiable camera/rays primitives, Dataclass manipulable as numpy arrays,...

The goal is to allow downstream ML research codebase to avoid re-implementing the same set of primitives and facilitate interoperability across codebases.
