### PR TITLE
add Customizable Perturbation Synthesis for Robust SLAM Benchmarking (study NeRF-based SLAM robustness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A curated list of awesome neural radiance fields papers, inspired by [awesome-co
 - [3D Neural Scene Representations for Visuomotor Control](https://3d-representation-learning.github.io/nerf-dy/), Li et al., CoRL 2021 Oral | [bibtex](./citations/nerf-dy.txt)
 - [Vision-Only Robot Navigation in a Neural Radiance World](https://arxiv.org/abs/2110.00168), Adamkiewicz et al., RA-L 2022 Vol.7 No.2 | [bibtex](./citations/vision-only.txt)
 - [Differentiable Physics Simulation of Dynamics-Augmented Neural Objects](https://arxiv.org/abs/2210.09420), Le Cleac'h et al., RA-L 2023 | [bibtex](./citations/dano.txt)
+- [Customizable Perturbation Synthesis for Robust SLAM Benchmarking](https://arxiv.org/abs/2402.08125), Xu et al., ArXiv 2024 | [bibtex](./citations/customizable-SLAM.txt)
 </details>
 
 <details open>

--- a/citations/customizable-SLAM.txt
+++ b/citations/customizable-SLAM.txt
@@ -1,0 +1,6 @@
+@article{xu2024customizable,
+  title={Customizable Perturbation Synthesis for Robust SLAM Benchmarking},
+  author={Xu, Xiaohao and Zhang, Tianyi and Wang, Sibo and Li, Xiang and Chen, Yongqi and Li, Ye and Raj, Bhiksha and Johnson-Roberson, Matthew and Huang, Xiaonan},
+  journal={arXiv preprint arXiv:2402.08125},
+  year={2024}
+}


### PR DESCRIPTION
# Pull requests instruction

1. Put the bibtex in `awesome-NeRF/citations/<YOUR-PROJECT>.txt`.
2. Modify the README and follow the format TITLE, AUTHOR, CONFERENCE YEAR | OPTIONAL LINK | BIBTEX. For example:
- [NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis](https://www.matthewtancik.com/nerf), Mildenhall et al., ECCV 2020 | [github](https://github.com/bmild/nerf)  | [bibtex](./citations/nerf.txt)
